### PR TITLE
Add Amber topology support to extract_dihedral_entropy.py

### DIFF
--- a/apps/extract_dihedral_entropy.py
+++ b/apps/extract_dihedral_entropy.py
@@ -57,16 +57,24 @@ def get_resi_mapping(inds_file, top_File):
     multimers), but rather the index according to the topology. 
     """
     inds = np.loadtxt(inds_file, delimiter=",")
-    structure = md.load(top_File)
-    n_resis = structure.top.n_residues
+    if top_File[-7:] == '.prmtop' or top_File[-4:] == '.top':
+        structure = md.load_prmtop(top_File)
+        n_resis = structure.n_residues
+    else:
+        structure = md.load(top_File)
+        n_resis = structure.top.n_residues
     n_dihedrals = inds.shape[0]
     resi_map = np.zeros(n_dihedrals)
     for i, n in enumerate(inds):
         atom_index = n[1]
-        resi_index = structure.top.atom(int(atom_index)).residue.index
+        if top_File[-7:] == '.prmtop' or top_File[-4:] == '.top':
+            resi_index = structure.atom(int(atom_index)).residue.index
+        else:
+            resi_index = structure.top.atom(int(atom_index)).residue.index
         resi_map[i] = resi_index
 
     return resi_map
+
 
 def sum_entropies_by_residue(resi_map, entropies):
     """This function will take the mapping produced in get_resi_mapping and 
@@ -103,10 +111,16 @@ def save_dihedral_entropy(entropy_values, resi_map, output_name):
     return 0 
 
 def get_residue_seqIds(resi_list, top_file):
-    structure = md.load(top_file)
+    if top_file[-7:] == '.prmtop' or top_file[-4:] == '.top':
+        structure = md.load_prmtop(top_file)
+    else:
+        structure = md.load(top_file)
     resSeq_list = np.zeros(resi_list.shape[0])
     for i, n in enumerate(resi_list):
-        resSeq_list[i] = structure.top.residue(int(n)).resSeq
+        if top_file[-7:] == '.prmtop' or top_file[-4:] == '.top':
+            resSeq_list[i] = structure.residue(int(n)).resSeq
+        else:
+            resSeq_list[i] = structure.top.residue(int(n)).resSeq
 
     return resSeq_list
 
@@ -165,6 +179,4 @@ if __name__ == "__main__":
     #trajDir = "/home/sukrit/work/vp35"
     #topologyName = "/home/sukrit/work/vp35/prot_only.pdb"
     main(args)
-
-
 

--- a/apps/extract_dihedral_entropy.py
+++ b/apps/extract_dihedral_entropy.py
@@ -57,11 +57,13 @@ def get_resi_mapping(inds_file, top_File):
     multimers), but rather the index according to the topology. 
     """
     inds = np.loadtxt(inds_file, delimiter=",")
+
+    # Handle support for Amber-style topology files
     if top_File[-7:] == '.prmtop' or top_File[-4:] == '.top':
-        structure = md.load_prmtop(top_File)
+        structure = md.load_prmtop(top_File)    # mdtraj.load only supports trajectories, but we only need topology information here
         n_resis = structure.n_residues
-    else:
-        structure = md.load(top_File)
+    else:    # non-Amber style topology files
+        structure = md.load(top_File)    # supports file formats with combined trajectory/topology information, like .pdb
         n_resis = structure.top.n_residues
     n_dihedrals = inds.shape[0]
     resi_map = np.zeros(n_dihedrals)
@@ -111,10 +113,11 @@ def save_dihedral_entropy(entropy_values, resi_map, output_name):
     return 0 
 
 def get_residue_seqIds(resi_list, top_file):
+    # Handle support for Amber-style topology files
     if top_file[-7:] == '.prmtop' or top_file[-4:] == '.top':
-        structure = md.load_prmtop(top_file)
-    else:
-        structure = md.load(top_file)
+        structure = md.load_prmtop(top_file)    # mdtraj.load only supports trajectories, but we only need topology information here
+    else:    # non-Amber style topology files
+        structure = md.load(top_file)    # supports file formats with combined trajectory/topology information, like .pdb
     resSeq_list = np.zeros(resi_list.shape[0])
     for i, n in enumerate(resi_list):
         if top_file[-7:] == '.prmtop' or top_file[-4:] == '.top':

--- a/apps/extract_dihedral_entropy.py
+++ b/apps/extract_dihedral_entropy.py
@@ -62,7 +62,7 @@ def get_resi_mapping(inds_file, top_File):
     if top_File[-7:] == '.prmtop' or top_File[-4:] == '.top':
         structure = md.load_prmtop(top_File)    # mdtraj.load only supports trajectories, but we only need topology information here
         n_resis = structure.n_residues
-    else:    # non-Amber style topology files
+    else:    # non-Amber-style topology files
         structure = md.load(top_File)    # supports file formats with combined trajectory/topology information, like .pdb
         n_resis = structure.top.n_residues
     n_dihedrals = inds.shape[0]
@@ -70,9 +70,9 @@ def get_resi_mapping(inds_file, top_File):
     for i, n in enumerate(inds):
         atom_index = n[1]
         if top_File[-7:] == '.prmtop' or top_File[-4:] == '.top':
-            resi_index = structure.atom(int(atom_index)).residue.index
+            resi_index = structure.atom(int(atom_index)).residue.index    # if we loaded an Amber-style topology, structure is already a toplogy object
         else:
-            resi_index = structure.top.atom(int(atom_index)).residue.index
+            resi_index = structure.top.atom(int(atom_index)).residue.index    # if we loaded a trajectory, structure.top is the topology object
         resi_map[i] = resi_index
 
     return resi_map
@@ -116,14 +116,14 @@ def get_residue_seqIds(resi_list, top_file):
     # Handle support for Amber-style topology files
     if top_file[-7:] == '.prmtop' or top_file[-4:] == '.top':
         structure = md.load_prmtop(top_file)    # mdtraj.load only supports trajectories, but we only need topology information here
-    else:    # non-Amber style topology files
+    else:    # non-Amber-style topology files
         structure = md.load(top_file)    # supports file formats with combined trajectory/topology information, like .pdb
     resSeq_list = np.zeros(resi_list.shape[0])
     for i, n in enumerate(resi_list):
         if top_file[-7:] == '.prmtop' or top_file[-4:] == '.top':
-            resSeq_list[i] = structure.residue(int(n)).resSeq
+            resSeq_list[i] = structure.residue(int(n)).resSeq    # if we loaded an Amber-style topology, structure is already a toplogy object
         else:
-            resSeq_list[i] = structure.top.residue(int(n)).resSeq
+            resSeq_list[i] = structure.top.residue(int(n)).resSeq    # if we loaded a trajectory, structure.top is the topology object
 
     return resSeq_list
 


### PR DESCRIPTION
Adds support for Amber-format .prmtop (or .top) files when using extract_dihedral_entropy.py from the command line.

Previously this tool would fail when supplied an Amber topology file because mdtraj's format-agnostic load function does not support creating topology files without an associated trajectory. This change is a workaround that replaces the format-agnostic load function with the appropriate format-specific function whenever the topology filename ends in '.prmtop' or '.top'.